### PR TITLE
bug/fix-screenshot-image-cutt-off-bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spring-media/storybook-addon-image-snapshots",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Storybook plugin for taking image snapshots of your stories based on @storybook/addon-storyshots-puppeteer plugin.",
   "main": "dist/index.js",
   "files": [

--- a/playground/stories/viewports.stories.js
+++ b/playground/stories/viewports.stories.js
@@ -27,15 +27,15 @@ const largeElementTemplate = `
   <div 
     class="large-element" 
     style="
-    background: red; 
+    background: #495057; 
     width: 900px; 
     height: 2000px;
     padding-top: 10px;
     padding-bottom: 10px;
     margin-top: 10px;
     margin-bottom: 10px;
-    border-top: 10px solid green;
-    border-bottom: 10px solid yellow;
+    border-top: 10px solid #3EB62B;
+    border-bottom: 10px solid #55ACEE;
   ">
   </div>
 </div>`;

--- a/playground/stories/viewports.stories.js
+++ b/playground/stories/viewports.stories.js
@@ -28,7 +28,7 @@ const largeElementTemplate = `
     class="large-element" 
     style="
     background: #495057; 
-    width: 900px; 
+    width: 500px; 
     height: 2000px;
     padding-top: 10px;
     padding-bottom: 10px;
@@ -68,7 +68,7 @@ LargeElementSmallViewport.story = {
       selector: '.large-element',
     },
     viewport: {
-      defaultViewport: 'medium',
+      defaultViewport: 'small',
     },
   },
 };

--- a/playground/stories/viewports.stories.js
+++ b/playground/stories/viewports.stories.js
@@ -21,3 +21,54 @@ SmallViewport.story = {
     },
   },
 };
+
+const largeElementTemplate = `
+<div>
+  <div 
+    class="large-element" 
+    style="
+    background: red; 
+    width: 900px; 
+    height: 2000px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    border-top: 10px solid green;
+    border-bottom: 10px solid yellow;
+  ">
+  </div>
+</div>`;
+
+export const LargeElementDefaultViewport = () => largeElementTemplate;
+LargeElementDefaultViewport.story = {
+  parameters: {
+    imageSnapshots: {
+      selector: '.large-element',
+    },
+  },
+};
+
+export const LargeElementMediumViewport = () => largeElementTemplate;
+LargeElementMediumViewport.story = {
+  parameters: {
+    imageSnapshots: {
+      selector: '.large-element',
+    },
+    viewport: {
+      defaultViewport: 'medium',
+    },
+  },
+};
+
+export const LargeElementSmallViewport = () => largeElementTemplate;
+LargeElementSmallViewport.story = {
+  parameters: {
+    imageSnapshots: {
+      selector: '.large-element',
+    },
+    viewport: {
+      defaultViewport: 'medium',
+    },
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,17 @@ const beforeScreenshot = async (page: puppeteer.Page, { context }: ScreenshotOpt
   const { x, y, width, height } = await page.evaluate(
     ({ selector }) => {
       const element = document.querySelector(selector);
-      const { x, y, width, height } = element.getBoundingClientRect();
-      return { x, y, width: Math.ceil(width), height: Math.ceil(height) };
+      const { x: left, y: top, width, height } = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      const marginTop = parseInt(style.marginTop);
+      const marginBottom = parseInt(style.marginBottom);
+
+      return {
+        x: left,
+        y: Math.ceil(top - marginTop),
+        width: Math.ceil(width),
+        height: Math.ceil(height + marginTop + marginBottom),
+      };
     },
     { selector },
   );


### PR DESCRIPTION
## What's changed and why
- Get margin top and margin bottom of element in order to adjust clip path, `getBoundingClientRect` retrieves the elements dimensions plus padding, some of our elements rely on margins to be displayed correctly hence why some of the screenshots were cut off at the bottom.
- Add stories to test large elements with padding and margins

Adjusts the clip path to start at the margin top of the element
```typescript
y: Math.ceil(top - marginTop),
```

Adjusts the clip path to take a screenshot of the full height of the element including its margins
```
height: Math.ceil(height + marginTop + marginBottom),
```